### PR TITLE
dev: pass html-options from repo-config

### DIFF
--- a/src/logseq/publish_spa.cljs
+++ b/src/logseq/publish_spa.cljs
@@ -85,6 +85,7 @@
                        static-dir
                        graph-dir
                        output-path
-                       (merge (build-common-export-options options) {:repo-config repo-config}))))
+                       (merge (build-common-export-options options) {:repo-config repo-config
+                                                                     :html-options (:html-options repo-config)}))))
 
 #js {:main -main}


### PR DESCRIPTION
Currently, the underlying export function supports receiving a `html-options` map for configurating the published html but it seems that this cli has not supported this feature yet.

This PR makes the `publish-spa` cli read the `hrml-options` from the repo config(a.k.a `logsq.edn`) and enable the user to control the generated html.

After https://github.com/logseq/logseq/pull/11149 being merged, user can also define extra scripts they want to include into the published html in their `logseq.edn`