### PR TITLE
Update actions/checkout@v3 -> v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Publish Logseq graph
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: logseq/publish-spa@v0.3.0
       - name: Add a nojekyll file # to make sure asset paths are correctly identified
         run: touch $GITHUB_WORKSPACE/www/.nojekyll

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
   steps:
     # First, build logseq's static/ and publishing assets
     - name: Checkout logseq
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: logseq/logseq
         path: .logseq-logseq
@@ -35,7 +35,7 @@ runs:
 
     ## Placed here since node step requires it
     - name: Checkout action
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: logseq/publish-spa
         path: .logseq-publish-spa


### PR DESCRIPTION
`checkout@v3` uses Node 16 and GitHub has deprecated Node 16 actions ([Ref](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)).

\cc @logseq-cldwalker 