### PR TITLE
Switch from Node 18 (EOL) to Node LTS

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,9 +47,9 @@ runs:
         bb: 1.2.174
 
     - name: Set up Node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v5
       with:
-        node-version: '18'
+        node-version: 'lts/*'
         cache: 'yarn'
         cache-dependency-path: .logseq-publish-spa/yarn.lock
 


### PR DESCRIPTION
Node v18 reached end of life in March 2025 and is incompatible with many packages commonly used in action workflows currently.

This PR switches to using the latest LTS release instead. (If you prefer pinning a version, let me know or feel free to change it)