### PR TITLE
fix: bump Node to 22 for logseq nightly engines requirement

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ runs:
     - name: Set up Node
       uses: actions/setup-node@v5
       with:
-        node-version: '20'
+        node-version: '22'
         cache: 'yarn'
         cache-dependency-path: .logseq-publish-spa/yarn.lock
 


### PR DESCRIPTION
## Problem

Builds using `version: nightly` (and any current logseq frontend commit) fail with:

```
error logseq@0.0.1: The engine "node" is incompatible with this module. Expected version ">=22.20.0". Got "20.20.2"
error Found incompatible module.
##[error]Process completed with exit code 1.
```

Example failing run: https://github.com/liby/liby/actions/runs/24714459918

## Root cause

[logseq/logseq `package.json`](https://github.com/logseq/logseq/blob/master/package.json) now declares `engines.node": ">=22.20.0"`, but this action pins `node-version: '20'` in `action.yml` (introduced by 394c988 to keep compatibility with then-current nbb-logseq).

## Why Node 22 is safe now

nbb-logseq 1.2.173 (the version pinned here via `bb: 1.2.174` / related deps) already has `engines.node": ">=20.10.0"` in its [`package.json`](https://github.com/logseq/nbb-logseq/blob/main/package.json), so moving to 22 does not regress the concern that motivated #46's revert.

## Why explicit `'22'` instead of `'lts/*'`

`lts/*` auto-rolls when a new Node major becomes LTS, which is exactly what burned #46 last time. Pinning to `'22'` keeps the upgrade intentional.

## Change

Single line in `action.yml`: `node-version: '20'` → `'22'`.